### PR TITLE
logstash-core-plugin-api to 2.0

### DIFF
--- a/logstash-output-rollbar2.gemspec
+++ b/logstash-output-rollbar2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_development_dependency "logstash-devutils"
 end
 


### PR DESCRIPTION
@filiptepper is there any reason this can't be merged? It allows this plugin to be consumed by logstash 6.1.1 